### PR TITLE
Add CI workflow to check for commonly misspelled words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,9 @@
+# See: https://github.com/codespell-project/codespell#using-a-config-file
+[codespell]
+# In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
+ignore-words-list =
+skip = ./.git
+builtin = clear,informal,en-GB_to_en-US
+check-filenames =
+check-hidden =
+

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,7 +1,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list =
+ignore-words-list = ,
 skip = ./.git
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =

--- a/.github/workflows/spell-check-task.yml
+++ b/.github/workflows/spell-check-task.yml
@@ -1,0 +1,41 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/spell-check-task.md
+name: Spell Check
+
+env:
+  # See: https://github.com/actions/setup-python/tree/v2#available-versions-of-python
+  PYTHON_VERSION: "3.9"
+
+# See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch new misspelling detections resulting from dictionary updates.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install Poetry
+        run: pip install poetry
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Spell check
+        run: task general:check-spelling

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 `.github`
 =========
+[![Spell Check status](https://github.com/miyo-reader/.github/actions/workflows/spell-check-task.yml/badge.svg)](https://github.com/miyo-reader/.github/actions/workflows/spell-check-task.yml)
+
 A collection of reusable assets for the Miyo Reader project.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,18 @@
+# See: https://taskfile.dev/#/usage
+version: "3"
+
+tasks:
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/poetry-task/Taskfile.yml
+  poetry:install-deps:
+    desc: Install dependencies managed by Poetry
+    cmds:
+      - poetry install --no-root
+
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/spell-check-task/Taskfile.yml
+  general:check-spelling:
+    desc: Check for commonly misspelled words
+    deps:
+      - task: poetry:install-deps
+    cmds:
+      - poetry run codespell
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,0 +1,22 @@
+[[package]]
+name = "codespell"
+version = "2.1.0"
+description = "Codespell"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["check-manifest", "flake8", "pytest", "pytest-cov", "pytest-dependency"]
+hard-encoding-detection = ["chardet"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "9b82f653df8b27353719532dec8326a8882ac694180086bb6c404dbd6863f4f7"
+
+[metadata.files]
+codespell = [
+    {file = "codespell-2.1.0-py3-none-any.whl", hash = "sha256:b864c7d917316316ac24272ee992d7937c3519be4569209c5b60035ac5d569b5"},
+    {file = "codespell-2.1.0.tar.gz", hash = "sha256:19d3fe5644fef3425777e66f225a8c82d39059dcfe9edb3349a8a2cf48383ee5"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = ".github-miyo"
+version = "0.0.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+python = "^3.9"
+
+[tool.poetry.dev-dependencies]
+codespell = "^2.1.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
On every push, pull request, and periodically, use [codespell](https://github.com/codespell-project/codespell) to check for commonly misspelled words.

In the event of a false positive, the problematic word should be added, in all lowercase, to the `ignore-words-list` field of `.codespellrc`. Regardless of the case of the word in the false positive, it must be in all lowercase in the ignore list. The ignore list is comma-separated with no spaces.